### PR TITLE
Update gradle-wrapper-validation.yml

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -7,4 +7,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v3
+      - uses: gradle/actions/wrapper-validation@v4


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for Gradle wrapper validation to use the latest version of the action.

* [`.github/workflows/gradle-wrapper-validation.yml`](diffhunk://#diff-3acb0e7569fe716eba818b083b47feb279a0290085f9655e946f21c54d8a947dL10-R10): Updated the Gradle wrapper validation action from `gradle/wrapper-validation-action@v3` to `gradle/actions/wrapper-validation@v4` to ensure compatibility with the latest features and improvements.